### PR TITLE
underscore import for cq package

### DIFF
--- a/server.go
+++ b/server.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/daaku/go.httpgzip"
 	"github.com/jmoiron/sqlx"
-	"gopkg.in/cq.v1"
+	_ "gopkg.in/cq.v1"
 	"gopkg.in/cq.v1/types"
 )
 


### PR DESCRIPTION
It is only needed for side effect (driver registration)
Solves compilation error:
`./server.go:13: imported and not used: "gopkg.in/cq.v1" as cq`